### PR TITLE
header URLs: change all relative to absolute

### DIFF
--- a/assets/html/_header.html
+++ b/assets/html/_header.html
@@ -17,9 +17,9 @@
     </span>
     <div class="myncbi">
       <span style="display:none" id="myncbiusername">
-        <a id="mnu" title="Edit account settings" href="/account/settings/"></a>
+        <a id="mnu" title="Edit account settings" href="https://www.ncbi.nlm.nih.gov/account/settings/"></a>
       </span>
-      <a style="display:none" id="myncbi" href="/myncbi/" accesskey="2">My NCBI</a>
+      <a style="display:none" id="myncbi" href="https://www.ncbi.nlm.nih.gov/myncbi/" accesskey="2">My NCBI</a>
       <a id="sign_in" href="https://www.ncbi.nlm.nih.gov/labs/account/">Log in</a>
       <a id="sign_out" style="display:none" href="https://www.ncbi.nlm.nih.gov/account/signout/">Log out</a>
     </div>


### PR DESCRIPTION
There were two My NCBI links that were relative, while the account links were absolute to www.  Changed to make all consistent (absolute).